### PR TITLE
You cannot use sanitize functions to escape❗👨🏻‍🏫 

### DIFF
--- a/block/templates/content-faq-item.php
+++ b/block/templates/content-faq-item.php
@@ -19,11 +19,11 @@ $faq_post   = $args['faq_post'] ?? '';
 $class_name = $args['class_name'] ?? '';
 
 ?>
-<details class="<?php echo sanitize_html_class( $class_name ); ?>__item">
-	<summary class="<?php echo sanitize_html_class( $class_name ); ?>__title">
+<details class="<?php echo esc_attr( $class_name ); ?>__item">
+	<summary class="<?php echo esc_attr( $class_name ); ?>__title">
 		<?php echo esc_html( get_the_title( $faq_post ) ); ?>
 	</summary>
-	<div class="<?php echo sanitize_html_class( $class_name ); ?>__content">
+	<div class="<?php echo esc_attr( $class_name ); ?>__content">
 		<?php echo apply_filters( 'the_content', $faq_post->post_content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</div>
 </details>


### PR DESCRIPTION
sixa FAQ Block did not make it through review at wordpress.org ☹️  with the following justification:

> ## Variables and options must be escaped when echo'd
> Much related to sanitizing everything, all variables that are echoed need to be escaped when they're echoed, so it can't hijack users or (worse) admin screens. There are many esc_*() functions you can use to make sure you don't show people the wrong data, as well as some that will allow you to echo HTML safely. 
>
> At this time, we ask you escape all $-variables, options, and any sort of generated data when it is being echoed. That means you should not be escaping when you build a variable, but when you output it at the end. We call this 'escaping late.'
>
> Besides protecting yourself from a possible XSS vulnerability, escaping late makes sure that you're keeping the future you safe. While today your code may be only outputted hardcoded content, that may not be true in the future. By taking the time to properly escape when you echo, you prevent a mistake in the future from becoming a critical security issue.
>
> This remains true of options you've saved to the database. Even if you've properly sanitized when you saved, the tools for sanitizing and escaping aren't interchangeable (except for esc_url(), and yes, we know that's confusing). Sanitizing makes sure it's safe for processing and storing in the database. Escaping makes it safe to output.
>
> Also keep in mind that sometimes a function is echoing when it should really be returning content instead. This is a common mistake when it comes to returning JSON encoded content. Very rarely is that actually something you should be echoing at all. Echoing is because it needs to be on the screen, read by a human. Returning (which is what you would do with an API) can be json encoded, though remember to sanitize when you save to that json object!
>
> There are a number of options to secure all types of content (html, email, etc). Yes, even HTML needs to be properly escaped.
>
> https://developer.wordpress.org/plugins/security/securing-output/
>
> Remember: You must use the most appropriate functions for the context. There is pretty much an option for everything you could echo. Even echoing HTML safely.
>
> Example(s) from your plugin:
>
> ```
> block/templates/content-faq-item.php:22:<details class="<?php echo sanitize_html_class( $class_name ); __item">
> block/templates/content-faq-item.php:23:	<summary class="<?php echo sanitize_html_class( $class_name ); __title">
> block/templates/content-faq-item.php:26:	<div class="<?php echo sanitize_html_class( $class_name ); __content">
> ```
>
> You cannot use sanitize functions to escape.


I have thus replaced `sanitize_html_class` with `esc_attr`.