### PR TITLE
Default Icon 🔺 

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -8,11 +8,29 @@ $prefix: sixa;
 .wp-block-#{$prefix}-faq {
 
 	&__title {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
 		list-style: none;
 		cursor: pointer;
 
 		&:focus {
 			outline: 0;
+		}
+
+		&::after {
+			content: "";
+			width: 0;
+			height: 0;
+			border-left: 8px solid transparent;
+			border-right: 8px solid transparent;
+			border-top: 8px solid var(--wp--custom--color--paragraph, #000);
+			transition: transform 300ms ease;
+		}
+
+		[open] > &::after {
+			transform: rotate(180deg);
 		}
 	}
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -25,7 +25,7 @@ $prefix: sixa;
 			height: 0;
 			border-left: 8px solid transparent;
 			border-right: 8px solid transparent;
-			border-top: 8px solid var(--wp--custom--color--paragraph, #000);
+			border-top: 8px solid currentColor;
 			transition: transform 300ms ease;
 		}
 


### PR DESCRIPTION
Although the name says "chevron", this PR introduces a triangle as the default icon for the FAQ items. Creating a chevron via CSS only would be substantially more complicated. For the first release I think this is okay and we should revisit a custom icon picker in a future update.