### PR TITLE
Missing files in `.bundleignore`

### DIFF
--- a/.bundleignore
+++ b/.bundleignore
@@ -24,3 +24,4 @@ renovate.json
 README.md
 /src
 *.zip
+svn

--- a/.bundleignore
+++ b/.bundleignore
@@ -1,4 +1,5 @@
 .bundleignore
+.eslintrc.js
 .git
 .github
 .DS_Store
@@ -11,6 +12,7 @@
 .stylelintignore
 .stylelintrc.js
 .wordpress-org
+babel.config.js
 composer.json
 composer.lock
 docs

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ build/
 
 # Plugin Archive
 *.zip
+
+# SVN Directory
+svn/


### PR DESCRIPTION
Just a minor change in `.bundleignore` to keep a few config files out of the plugin .zip file.

EDIT: I have also added the `svn` directory to `.gitignore`.