### PR TITLE
Remove Safari browser markers

### DIFF
--- a/block/templates/content-faq-item.php
+++ b/block/templates/content-faq-item.php
@@ -21,7 +21,9 @@ $class_name = $args['class_name'] ?? '';
 ?>
 <details class="<?php echo esc_attr( $class_name ); ?>__item">
 	<summary class="<?php echo esc_attr( $class_name ); ?>__title">
-		<?php echo esc_html( get_the_title( $faq_post ) ); ?>
+		<span class="<?php echo esc_attr( $class_name ); ?>__container">
+			<?php echo esc_html( get_the_title( $faq_post ) ); ?>
+		</span>
 	</summary>
 	<div class="<?php echo esc_attr( $class_name ); ?>__content">
 		<?php echo apply_filters( 'the_content', $faq_post->post_content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/block/templates/content-faq-item.php
+++ b/block/templates/content-faq-item.php
@@ -21,9 +21,7 @@ $class_name = $args['class_name'] ?? '';
 ?>
 <details class="<?php echo esc_attr( $class_name ); ?>__item">
 	<summary class="<?php echo esc_attr( $class_name ); ?>__title">
-		<span class="<?php echo esc_attr( $class_name ); ?>__container">
-			<?php echo esc_html( get_the_title( $faq_post ) ); ?>
-		</span>
+		<?php echo esc_html( get_the_title( $faq_post ) ); ?>
 	</summary>
 	<div class="<?php echo esc_attr( $class_name ); ?>__content">
 		<?php echo apply_filters( 'the_content', $faq_post->post_content ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>

--- a/src/style.scss
+++ b/src/style.scss
@@ -7,7 +7,23 @@ $prefix: sixa;
 
 .wp-block-#{$prefix}-faq {
 
+	&__item {
+
+		&[open] .wp-block-sixa-faq__container::after {
+			transform: rotate(180deg);
+		}
+	}
+
 	&__title {
+
+		&::-webkit-details-marker,
+		&::marker {
+			display: none;
+			content: "";
+		}
+	}
+
+	&__container {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -27,10 +43,6 @@ $prefix: sixa;
 			border-right: 8px solid transparent;
 			border-top: 8px solid currentColor;
 			transition: transform 300ms ease;
-		}
-
-		[open] > &::after {
-			transform: rotate(180deg);
 		}
 	}
 

--- a/src/style.scss
+++ b/src/style.scss
@@ -7,23 +7,7 @@ $prefix: sixa;
 
 .wp-block-#{$prefix}-faq {
 
-	&__item {
-
-		&[open] .wp-block-sixa-faq__container::after {
-			transform: rotate(180deg);
-		}
-	}
-
 	&__title {
-
-		&::-webkit-details-marker,
-		&::marker {
-			display: none;
-			content: "";
-		}
-	}
-
-	&__container {
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -43,6 +27,14 @@ $prefix: sixa;
 			border-right: 8px solid transparent;
 			border-top: 8px solid currentColor;
 			transition: transform 300ms ease;
+		}
+
+		[open] > &::after {
+			transform: rotate(180deg);
+		}
+
+		&::-webkit-details-marker {
+			display: none;
 		}
 	}
 


### PR DESCRIPTION
This PR proposes a few layout fixes and adjustments required for Safari.

Initially I have removed the browser marker from Safari but aligning the content and the `::after` element via `display: flex;` does not seem to be possible in Safari due to a spec limitation (elaborated upon in this, more general, [post](https://stackoverflow.com/a/35466231)).

Because certain HTML elements such as `<summary>`, `<fieldset>`, `<button>` etc. cannot be flex or grid containers the most widely accepted solution seems to be wrapping the content of said element in another wrapper such as a `<span>`. As a comment on the said post suggests:

> A `div` can't be a child of a `button` because, if you think of it in old-school HTML, a block-level element can't be a child of an inline-level element. But today, with HTML5, the technically correct answer is that a `button` element can only accept _Phrasing Content._ A `span` represents _Phrasing Content_, but a `div` does not. A div represents _Flow Content_. [MDN reference](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories).

I have thus added another wrapper to the summary content and removed the new marker generated in Chromium browsers. I have also moved the `rotate` functionality under the `__item` as I could not use the `[open]` state from that level anymore. Please let me know if I have omitted a better way to handle this.

![image](https://user-images.githubusercontent.com/24987594/150165666-c83ca086-8367-48df-9f86-fb14deac570d.png)

![image](https://user-images.githubusercontent.com/24987594/150165822-6208d4fc-8a2b-4787-a7c8-4737df481b6c.png)
